### PR TITLE
[Hotfix] Fix Apple September event date

### DIFF
--- a/js/addNewEvent.js
+++ b/js/addNewEvent.js
@@ -11,7 +11,7 @@ year = 2020,
 // Format: MM (09) or M (9), both are valid 
 month = 09,
 // Format: DD (09) or D (9), both are valid
-day = 28  
+day = 15  
 // Format: 0 - 24 / 5 == 5 AM / 17 == 5 PM 
 hour = 10,
 // Format: MM (09) or M (9), both are valid


### PR DESCRIPTION
It seemed I messed up the day for the upcoming event. This change should fix it. Sorry!

https://www.apple.com/apple-events/
![Screenshot 2020-09-08 at 17 27 45](https://user-images.githubusercontent.com/4670057/92496597-a0ca0900-f1f8-11ea-9b7b-4a81bb04da53.jpg)
