### PR TITLE
added nov event based on reports from bloomberg, jon prosser, Apple Insider and 9to5mac

### DIFF
--- a/js/addNewEvent.js
+++ b/js/addNewEvent.js
@@ -1,18 +1,18 @@
 /* --------------------------
 * UPDATE UPCOMING EVENT DATE
-* -------------------------- 
+* --------------------------
 *
 * IMPORTANT: The date has to be in the Pacific Standard Time (PST) zone
 *
 */
-const 
+const
 // Format: YYYY (2020)
 year = 2020,
-// Format: MM (09) or M (9), both are valid 
-month = 10,
+// Format: MM (09) or M (9), both are valid
+month = 11,
 // Format: DD (09) or D (9), both are valid
-day = 13  
-// Format: 0 - 24 / 5 == 5 AM / 17 == 5 PM 
+day = 17
+// Format: 0 - 24 / 5 == 5 AM / 17 == 5 PM
 hour = 10,
 // Format: MM (09) or M (9), both are valid
 minute = 00;
@@ -21,4 +21,4 @@ minute = 00;
 * UPDATE UPCOMING EVENT NAME
 * --------------------------
 */
-const eventName = 'Apple iPhone 12 Launch Event';
+const eventName = 'Apple Silicon Mac Launch Event';


### PR DESCRIPTION
Links to the reports:
[9to5mac](https://9to5mac.com/2020/10/15/apple-might-hold-another-event-on-november-17-to-introduce-first-apple-silicon-mac/)
[Jon Prosser](https://twitter.com/jon_prosser/status/1316908204681498624?s=20)
[Bloomberg's Mark Gurman](https://www.bloomberg.com/news/articles/2020-10-09/apple-prepares-to-launch-5g-iphones-into-unready-u-s-market)
[Apple Insider](https://appleinsider.com/articles/20/10/16/first-apple-silicon-mac-could-debut-on-nov-17)