### PR TITLE
Set event timezone to Pacific Standard Time (PST)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
-let start = new Date(month + '/' + day + '/' + year + ' ' + hour + ':' + minute + ' GMT-0700'),
-    end = new Date(month + '/' + day + '/' + year + ' ' + (hour+2) + ':' + minute + ' GMT-0700'),
+let start = new Date(month + '/' + day + '/' + year + ' ' + hour + ':' + minute + ' PST'),
+    end = new Date(month + '/' + day + '/' + year + ' ' + (hour+2) + ':' + minute + ' PST'),
     now = new Date(),
     distance = start - now,
     _second = 1000,


### PR DESCRIPTION
Apple always announces their event times in the PST time zone. However, in `main.js`, the time zone is hardcoded to `GMT-0700`, which can lead to wrong event times because daylight saving time is not automatically respected (for example in Germany, the website currently says "18:00" for the "One more thing" event, which should be "19:00"). I changed the time zone to PST, which should fix the issue.