### PR TITLE
Make page load a bit smoother

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -23,6 +23,7 @@ if (distance < -7200001) {
   $('#seconds').html('00');
 } else {
   $('#response').append(eventHtml);
+  showRemaining();
   timer = setInterval(showRemaining, 1000);
 }
 


### PR DESCRIPTION
When page loads, you have to wait a second before seeing actual remaining time:
![image](https://user-images.githubusercontent.com/12175048/98665438-5a0da200-2354-11eb-8083-a82e0a4fd055.png)

That happens because of how `setInterval` works. It calls the callback first time only after specified `interval` time passes. So, if we call the callback initially, we see the time instantly.