### PR TITLE
add WWDC 2021

### DIFF
--- a/js/addNewEvent.js
+++ b/js/addNewEvent.js
@@ -7,11 +7,11 @@
 */
 const 
 // Format: YYYY (2020)
-year = 2020,
+year = 2021,
 // Format: MM (09) or M (9), both are valid 
-month = 11,
+month = 06,
 // Format: DD (09) or D (9), both are valid
-day = 10  
+day = 07,  
 // Format: 0 - 24 / 5 == 5 AM / 17 == 5 PM 
 hour = 10,
 // Format: MM (09) or M (9), both are valid
@@ -21,4 +21,4 @@ minute = 00;
 * UPDATE UPCOMING EVENT NAME
 * --------------------------
 */
-const eventName = 'One more thing';
+const eventName = 'WWDC 2021';


### PR DESCRIPTION
https://www.apple.com/newsroom/2021/03/apples-worldwide-developers-conference-is-back-in-its-all-online-format/