### PR TITLE
Fix Spring Loaded time

### DIFF
--- a/js/addNewEvent.js
+++ b/js/addNewEvent.js
@@ -13,7 +13,7 @@ month = 04,
 // Format: DD (09) or D (9), both are valid
 day = 20,  
 // Format: 0 - 24 / 5 == 5 AM / 17 == 5 PM 
-hour = 10,
+hour = 09,
 // Format: MM (09) or M (9), both are valid
 minute = 00;
 


### PR DESCRIPTION
The Spring Loaded event is held on April 20 at 10:00 a.m. PDT.
The currently set time on the website is 10:00 a.m. PST, which is one hour too late.
See: [Apple's website](https://www.apple.com/apple-events/)