### PR TITLE
Use correct time zone for March event (winter time)

### DIFF
--- a/js/addNewEvent.js
+++ b/js/addNewEvent.js
@@ -6,7 +6,7 @@
  *
  */
 const // The time zone when the event will be held. Format: time zone identifier (e.g., "PDT" or "PST")
-	timeZone = 'PDT',
+	timeZone = 'PST',
 	// Format: YYYY (2020)
 	year = 2022,
 	// The month as a number, not the index


### PR DESCRIPTION
In the winter time (until the second Sunday of March), California uses the PST time zone, not PDT (which is for the summer time). For the WWDC keynote, we need to change it back to PDT again.

I noticed it because wheniskeynote.com said "18:00" in Germany, but Apple's website says "19:00".

Sources:
- [PST](https://en.wikipedia.org/wiki/UTC%E2%88%9207:00)
- [PDT](https://en.wikipedia.org/wiki/Daylight_saving_time)