### PR TITLE
WWDC 2022 (timezone correction)

### DIFF
--- a/js/addNewEvent.js
+++ b/js/addNewEvent.js
@@ -6,7 +6,7 @@
  *
  */
 const // The time zone when the event will be held. Format: time zone identifier (e.g., "PDT" or "PST")
-	timeZone = 'PST',
+	timeZone = 'PDT',
 	// Format: YYYY (2020)
 	year = 2022,
 	// The month as a number, not the index


### PR DESCRIPTION
More or less revert to new correct time zone based on changes in https://github.com/hartator/wheniskeynote.com/pull/42