### PR TITLE
Add WWDC 2025 Keynote (June 9, 2025)

### DIFF
--- a/js/addNewEvent.js
+++ b/js/addNewEvent.js
@@ -11,9 +11,9 @@ const // The time zone when the event will be held. Format: time zone identifier
 	year = 2025,
 	// The month as a number, not the index
 	// Format: MM (09) or M (9), both are valid
-	month = 02,
+	month = 06,
 	// Format: DD (09) or D (9), both are valid
-	day = 19,
+	day = 09,
 	// Format: 0 - 24 / 5 == 5 AM / 17 == 5 PM
 	hour = 10,
 	// Format: MM (09) or M (9), both are valid
@@ -23,4 +23,4 @@ const // The time zone when the event will be held. Format: time zone identifier
  * UPDATE UPCOMING EVENT NAME
  * --------------------------
  */
-const eventName = "Newest Member of the Family.";
+const eventName = "WWDC25 Keynote";


### PR DESCRIPTION
This PR adds the WWDC 2025 keynote event, scheduled for June 9, 2025 at 10:00 AM PT, as announced by Apple.

- Title: WWDC 2025 Keynote
- Date: 2025-06-09T10:00:00-07:00
- URL: https://www.apple.com/apple-events/

Source: https://www.macrumors.com/2025/03/29/top-stories-wwdc-2025-announced/